### PR TITLE
go_routerの実装

### DIFF
--- a/apps/flutter_sample_app/lib/app.dart
+++ b/apps/flutter_sample_app/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:core_model/build_config.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_sample_app/ui/router/router_provider.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class App extends ConsumerWidget {
@@ -7,15 +8,9 @@ class App extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final appName = ref.watch(buildConfigProvider).appName;
-
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: Text(appName),
+    return MaterialApp.router(
+      title: ref.watch(buildConfigProvider).appName,
+      routerConfig: ref.watch(routerProvider),
     );
   }
 }

--- a/apps/flutter_sample_app/lib/ui/router/base_routes/main_routes.dart
+++ b/apps/flutter_sample_app/lib/ui/router/base_routes/main_routes.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_sample_app/ui/router/branches/branch_type.dart';
+import 'package:flutter_sample_app/ui/router/branches/home_branch.dart';
+import 'package:flutter_sample_app/ui/router/branches/notification_branch.dart';
+import 'package:flutter_sample_app/ui/router/branches/profile_branch.dart';
+import 'package:flutter_sample_app/ui/router/component/bottom_navigation_scaffold.dart';
+import 'package:go_router/go_router.dart';
+
+part 'main_routes.g.dart';
+
+final _mainNavigatorKey = GlobalKey<NavigatorState>();
+const _branches = [
+  homeBranch,
+  notificationBranch,
+  profileBranch,
+];
+
+/// ページのルート
+/// TypedStatefulShellBranchをBranchTypeと同数作成しBottomNavigationによるページ切り替えを行う
+@TypedStatefulShellRoute<MainRoute>(branches: _branches)
+class MainRoute extends StatefulShellRouteData {
+  const MainRoute();
+  static final GlobalKey<NavigatorState> $navigatorKey = _mainNavigatorKey;
+
+  @override
+  Widget builder(
+    BuildContext context,
+    GoRouterState state,
+    StatefulNavigationShell navigationShell,
+  ) {
+    // branchesの数とBranchTypeの数が一致していない場合はエラーを出す
+    assert(
+      _branches.length == BranchType.values.length,
+      'branches.lengthとBranchType.values.lengthは同じである必要があります',
+    );
+
+    // 各Branchの最初のページにいるかどうか
+    final isOnBranchBase = BranchType.values
+        .any((branchType) => '/${branchType.name}' == state.fullPath);
+    // navigationShellはTypedStatefulShellBranchで定義したページなので、
+    // BottomNavigation有りのページが来た場合はBottomNavigationScaffoldでラップする
+    return isOnBranchBase
+        ? BottomNavigationScaffold(pageBody: navigationShell)
+        : navigationShell;
+  }
+}

--- a/apps/flutter_sample_app/lib/ui/router/base_routes/main_routes.g.dart
+++ b/apps/flutter_sample_app/lib/ui/router/base_routes/main_routes.g.dart
@@ -1,0 +1,100 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'main_routes.dart';
+
+// **************************************************************************
+// GoRouterGenerator
+// **************************************************************************
+
+List<RouteBase> get $appRoutes => [
+      $mainRoute,
+    ];
+
+RouteBase get $mainRoute => StatefulShellRouteData.$route(
+      factory: $MainRouteExtension._fromState,
+      branches: [
+        StatefulShellBranchData.$branch(
+          navigatorKey: SummaryBranch.$navigatorKey,
+          routes: [
+            GoRouteData.$route(
+              path: '/home',
+              factory: $HomeRouteExtension._fromState,
+            ),
+          ],
+        ),
+        StatefulShellBranchData.$branch(
+          navigatorKey: NotificationBranch.$navigatorKey,
+          routes: [
+            GoRouteData.$route(
+              path: '/notification',
+              factory: $NotificationRouteExtension._fromState,
+            ),
+          ],
+        ),
+        StatefulShellBranchData.$branch(
+          navigatorKey: ProfileBranch.$navigatorKey,
+          routes: [
+            GoRouteData.$route(
+              path: '/profile',
+              factory: $ProfileRouteExtension._fromState,
+            ),
+          ],
+        ),
+      ],
+    );
+
+extension $MainRouteExtension on MainRoute {
+  static MainRoute _fromState(GoRouterState state) => const MainRoute();
+}
+
+extension $HomeRouteExtension on HomeRoute {
+  static HomeRoute _fromState(GoRouterState state) => const HomeRoute();
+
+  String get location => GoRouteData.$location(
+        '/home',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $NotificationRouteExtension on NotificationRoute {
+  static NotificationRoute _fromState(GoRouterState state) =>
+      const NotificationRoute();
+
+  String get location => GoRouteData.$location(
+        '/notification',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $ProfileRouteExtension on ProfileRoute {
+  static ProfileRoute _fromState(GoRouterState state) => const ProfileRoute();
+
+  String get location => GoRouteData.$location(
+        '/profile',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/apps/flutter_sample_app/lib/ui/router/branches/branch_type.dart
+++ b/apps/flutter_sample_app/lib/ui/router/branches/branch_type.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// アプリ用のRoutingのブランチ(メニューのタブ)のタイプ
+enum BranchType {
+  home(
+    label: 'ホーム',
+    icon: Icons.home,
+  ),
+  notification(
+    label: 'おしらせ',
+    icon: Icons.notifications,
+  ),
+  profile(
+    label: 'マイページ',
+    icon: Icons.person,
+  ),
+  ;
+
+  const BranchType({
+    required this.label,
+    required this.icon,
+  });
+
+  final String label;
+  final IconData icon;
+}

--- a/apps/flutter_sample_app/lib/ui/router/branches/home_branch.dart
+++ b/apps/flutter_sample_app/lib/ui/router/branches/home_branch.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_sample_app/ui/router/branches/branch_type.dart';
+import 'package:flutter_sample_app/ui/router/utils/route_path_name.dart';
+import 'package:go_router/go_router.dart';
+
+/// BottomNavigationBar上のホームタブのブランチ
+const homeBranch = TypedStatefulShellBranch<SummaryBranch>(
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<HomeRoute>(
+      path: '/${RoutePathName.home}',
+    ),
+  ],
+);
+
+final GlobalKey<NavigatorState> _homeNavigatorKey = GlobalKey<NavigatorState>();
+
+class SummaryBranch extends StatefulShellBranchData {
+  const SummaryBranch();
+  static final GlobalKey<NavigatorState> $navigatorKey = _homeNavigatorKey;
+}
+
+/// ホームページ（タブ1つ目）のルート
+class HomeRoute extends GoRouteData {
+  const HomeRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      // TODO(sakurai): feature_homeを作成してこのScaffoldと差し替える
+      Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(BranchType.home.label),
+            ],
+          ),
+        ),
+      );
+}

--- a/apps/flutter_sample_app/lib/ui/router/branches/notification_branch.dart
+++ b/apps/flutter_sample_app/lib/ui/router/branches/notification_branch.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_sample_app/ui/router/branches/branch_type.dart';
+import 'package:flutter_sample_app/ui/router/utils/route_path_name.dart';
+import 'package:go_router/go_router.dart';
+
+/// BottomNavigationBar上のおしらせタブのブランチ
+const notificationBranch = TypedStatefulShellBranch<NotificationBranch>(
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<NotificationRoute>(
+      path: '/${RoutePathName.notification}',
+    ),
+  ],
+);
+
+final GlobalKey<NavigatorState> _notificationNavigatorKey =
+    GlobalKey<NavigatorState>();
+
+class NotificationBranch extends StatefulShellBranchData {
+  const NotificationBranch();
+  static final GlobalKey<NavigatorState> $navigatorKey =
+      _notificationNavigatorKey;
+}
+
+class NotificationRoute extends GoRouteData {
+  const NotificationRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => Scaffold(
+        body: Center(
+          child: Text(BranchType.notification.label),
+        ),
+      );
+}

--- a/apps/flutter_sample_app/lib/ui/router/branches/profile_branch.dart
+++ b/apps/flutter_sample_app/lib/ui/router/branches/profile_branch.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_sample_app/ui/router/branches/branch_type.dart';
+import 'package:flutter_sample_app/ui/router/utils/route_path_name.dart';
+import 'package:go_router/go_router.dart';
+
+/// BottomNavigationBar上のプロフィールタブのブランチ
+const profileBranch = TypedStatefulShellBranch<ProfileBranch>(
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<ProfileRoute>(
+      path: '/${RoutePathName.profile}',
+    ),
+  ],
+);
+
+final GlobalKey<NavigatorState> _profileNavigatorKey =
+    GlobalKey<NavigatorState>();
+
+class ProfileBranch extends StatefulShellBranchData {
+  const ProfileBranch();
+  static final GlobalKey<NavigatorState> $navigatorKey = _profileNavigatorKey;
+}
+
+/// プロフィールページのルート
+class ProfileRoute extends GoRouteData {
+  const ProfileRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => Scaffold(
+        body: Center(
+          child: Text(BranchType.profile.label),
+        ),
+      );
+}

--- a/apps/flutter_sample_app/lib/ui/router/component/bottom_navigation_scaffold.dart
+++ b/apps/flutter_sample_app/lib/ui/router/component/bottom_navigation_scaffold.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_sample_app/ui/router/branches/branch_type.dart';
+import 'package:go_router/go_router.dart';
+
+class BottomNavigationScaffold extends StatelessWidget {
+  const BottomNavigationScaffold({
+    required this.pageBody,
+    super.key,
+  });
+
+  final StatefulNavigationShell pageBody;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: pageBody,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: pageBody.currentIndex,
+        onTap: pageBody.goBranch,
+        items: BranchType.values
+            .map(
+              (e) => BottomNavigationBarItem(
+                icon: Icon(e.icon),
+                label: e.label,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/apps/flutter_sample_app/lib/ui/router/component/routing_error_page.dart
+++ b/apps/flutter_sample_app/lib/ui/router/component/routing_error_page.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class RoutingErrorPage extends StatelessWidget {
+  const RoutingErrorPage({
+    required this.state,
+    super.key,
+  });
+
+  // ignore: diagnostic_describe_all_properties
+  final GoRouterState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text('エラー'),
+      ),
+      body: Center(
+        child: Text(
+          state.error.toString(),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flutter_sample_app/lib/ui/router/router_provider.dart
+++ b/apps/flutter_sample_app/lib/ui/router/router_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_sample_app/ui/router/base_routes/main_routes.dart';
+import 'package:flutter_sample_app/ui/router/component/routing_error_page.dart';
+import 'package:flutter_sample_app/ui/router/utils/route_path_name.dart';
+import 'package:go_router/go_router.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'router_provider.g.dart';
+
+@riverpod
+GoRouter router(RouterRef ref) {
+  return GoRouter(
+    initialLocation: '/${RoutePathName.home}',
+    routes: [
+      $mainRoute,
+    ],
+    errorBuilder: (context, state) => RoutingErrorPage(state: state),
+  );
+}

--- a/apps/flutter_sample_app/lib/ui/router/router_provider.g.dart
+++ b/apps/flutter_sample_app/lib/ui/router/router_provider.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'router_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$routerHash() => r'0e25029d5635ea55e01b8648e08cce364a88d3db';
+
+/// See also [router].
+@ProviderFor(router)
+final routerProvider = AutoDisposeProvider<GoRouter>.internal(
+  router,
+  name: r'routerProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$routerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef RouterRef = AutoDisposeProviderRef<GoRouter>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/apps/flutter_sample_app/lib/ui/router/utils/route_path_name.dart
+++ b/apps/flutter_sample_app/lib/ui/router/utils/route_path_name.dart
@@ -1,0 +1,5 @@
+class RoutePathName {
+  static const String home = 'home';
+  static const String notification = 'notification';
+  static const String profile = 'profile';
+}


### PR DESCRIPTION
## 概要

- [go_router](https://pub.dev/packages/go_router)を入れました。
- [go_router_builder](https://pub.dev/packages/go_router_builder)を入れました。

## レビュー観点

- go_router_builderの使い方を把握する。
- go_routerをそのまま使うよりも、go_router_builderを使った方が良い点を見つけてみる。

応用

- StatefulShellRouteでボトムタブ内の永続化を理解する
- 参考：[go_routerでBottomNavigationBarの永続化に挑戦する](https://zenn.dev/flutteruniv_dev/articles/stateful_shell_route)

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [ ] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [x] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢